### PR TITLE
Filter out tweets with no ast

### DIFF
--- a/lib/fetchTweets.js
+++ b/lib/fetchTweets.js
@@ -41,6 +41,8 @@ const isValid2 = (tweet) => {
   return true;
 };
 
+const hasTweetAST = (tweet) => Boolean(tweet.value.tweet_ast);
+
 const buildTweetObject = (tweet) => {
   const text = tweet.full_text || tweet.text;
 
@@ -87,7 +89,7 @@ const buildTweetObject2 = async (tweet) => {
   }
 
   if (!tweetAst) {
-    console.log(`TWEET_AST_NULL for tweet: ${tweet.id}`);
+    console.log(`TWEET_AST_NULL for tweet: ${tweet.tweet_id}`);
   }
 
   return {
@@ -124,7 +126,7 @@ const fetchTweets = async () => {
   );
 
   // Discard any tweets that fail the `buildTweetObject2` process, without throwing any error
-  tweets = tweets.filter((result) => result.status == "fulfilled");
+  tweets = tweets.filter((result) => result.status == "fulfilled").filter(hasTweetAST);
   tweets = tweets.map((result) => result.value);
 
   // let tweets = await Promise.all(

--- a/lib/verifyTweet.js
+++ b/lib/verifyTweet.js
@@ -84,8 +84,6 @@ const verifyTweetText = (tweet) => {
     }
   }
 
-  console.log(tweet);
-  console.count("here");
   switch (config.default) {
     case "alwaysAdd":
       return 2;


### PR DESCRIPTION
Added a filter to filter out tweets with `null` ast.

This is a temporary solution.
I've created an issue in the react-static-tweets repository: https://github.com/transitive-bullshit/react-static-tweets/issues/43

Also, I've removed some unnecessary comments.

